### PR TITLE
Small extra step for those running without Trident

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ The collector stores metrics in graphite and presents those metrics through a se
 git clone https://github.com/jedimt/hcicollector
 # execute the install_hcicollector.sh script and provide the requested input 
 cd hcicollector; sudo ./install_hcicollector.sh
-# if no external storage, create local volume: docker volume create --name=chosen-graphite-volume-name
+# w/o Trident storage, create local volume using the volume name chosen in install wizard
+#   docker volume create --name=chosen-name
 # start up the containers
 sudo docker-compose up
 # to run in detached mode: sudo docker-compose up -d

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The collector stores metrics in graphite and presents those metrics through a se
 git clone https://github.com/jedimt/hcicollector
 # execute the install_hcicollector.sh script and provide the requested input 
 cd hcicollector; sudo ./install_hcicollector.sh
+# if no external storage, create local volume: docker volume create --name=chosen-graphite-volume-name
 # start up the containers
 sudo docker-compose up
 # to run in detached mode: sudo docker-compose up -d


### PR DESCRIPTION
For #13,  if no external storage add optional step to manually create local volume (could be addressed with "if no Trident settings provided, create local volume" in config wizard, but ...)